### PR TITLE
add virustotal

### DIFF
--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -5,6 +5,7 @@ import (
 	"github.com/projectdiscovery/urlfinder/pkg/source/alienvault"
 	"github.com/projectdiscovery/urlfinder/pkg/source/commoncrawl"
 	"github.com/projectdiscovery/urlfinder/pkg/source/urlscan"
+	"github.com/projectdiscovery/urlfinder/pkg/source/virustotal"
 	"github.com/projectdiscovery/urlfinder/pkg/source/waybackarchive"
 	mapsutil "github.com/projectdiscovery/utils/maps"
 )
@@ -14,6 +15,7 @@ var AllSources = map[string]source.Source{
 	"commoncrawl":    &commoncrawl.Source{},
 	"urlscan":        &urlscan.Source{},
 	"waybackarchive": &waybackarchive.Source{},
+	"virustotal":     &virustotal.Source{},
 }
 
 var sourceWarnings = mapsutil.NewSyncLockMap[string, string](

--- a/pkg/source/virustotal/virustotal.go
+++ b/pkg/source/virustotal/virustotal.go
@@ -1,0 +1,107 @@
+package virustotal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/projectdiscovery/urlfinder/pkg/session"
+	"github.com/projectdiscovery/urlfinder/pkg/source"
+	"github.com/projectdiscovery/urlfinder/pkg/utils"
+)
+
+type response struct {
+	DetectedUrls []struct {
+		URL string `json:"url"`
+	} `json:"detected_urls"`
+	Subdomains     []string        `json:"subdomains"`
+	UndetectedUrls [][]interface{} `json:"undetected_urls"`
+}
+
+type Source struct {
+	apiKeys   []string
+	timeTaken time.Duration
+	errors    int
+	results   int
+}
+
+func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session) <-chan source.Result {
+	results := make(chan source.Result)
+	s.errors = 0
+	s.results = 0
+
+	go func() {
+		defer func(startTime time.Time) {
+			s.timeTaken = time.Since(startTime)
+			close(results)
+		}(time.Now())
+
+		randomApiKey := utils.PickRandom(s.apiKeys, s.Name())
+		if randomApiKey == "" {
+			return
+		}
+
+		searchURL := fmt.Sprintf("https://www.virustotal.com/vtapi/v2/domain/report?apikey=%s&domain=%s", randomApiKey, rootUrl)
+		resp, err := sess.SimpleGet(ctx, searchURL)
+		if err != nil {
+			results <- source.Result{Source: s.Name(), Type: source.Error, Error: err}
+			s.errors++
+			sess.DiscardHTTPResponse(resp)
+			return
+		}
+		defer resp.Body.Close()
+
+		var data response
+		err = json.NewDecoder(resp.Body).Decode(&data)
+		if err != nil {
+			results <- source.Result{Source: s.Name(), Type: source.Error, Error: err}
+			s.errors++
+			return
+		}
+
+		for _, detectedUrl := range data.DetectedUrls {
+			results <- source.Result{Source: s.Name(), Value: detectedUrl.URL}
+			s.results++
+		}
+		for _, subdomain := range data.Subdomains {
+			results <- source.Result{Source: s.Name(), Value: subdomain}
+			s.results++
+		}
+
+		for _, undetectedUrl := range data.UndetectedUrls {
+			if len(undetectedUrl) > 0 {
+				if urlString, ok := undetectedUrl[0].(string); ok {
+					results <- source.Result{Source: s.Name(), Value: urlString}
+					s.results++
+				}
+			}
+		}
+
+	}()
+	return results
+}
+
+func (s *Source) Name() string {
+	return "virustotal"
+}
+
+func (s *Source) IsDefault() bool {
+	return true
+}
+
+func (s *Source) NeedsKey() bool {
+	return true
+}
+
+func (s *Source) AddApiKeys(keys []string) {
+	s.apiKeys = keys
+}
+
+func (s *Source) Statistics() source.Statistics {
+	return source.Statistics{
+		Errors:    s.errors,
+		Results:   s.results,
+		TimeTaken: s.timeTaken,
+	}
+}


### PR DESCRIPTION
Closes #13

```console
go run . -s virustotal -d hackerone.com

  __  _____  __   _____         __       
 / / / / _ \/ /  / __(_)__  ___/ /__ ____
/ /_/ / , _/ /__/ _// / _ \/ _  / -_) __/
\____/_/|_/____/_/ /_/_//_/\_,_/\__/_/    

                projectdiscovery.io

[INF] Current urlfinder version v0.0.1 (latest)
[INF] Loading provider config from /Users/dogancanbakir/Library/Application Support/urlfinder/provider-config.yaml
[INF] Enumerating urls for hackerone.com
https://hackerone.com/reports/2711714
http://hackerone.com/fady_othman
http://hackerone.com/reports/2167721
...
[INF] Found 123 urls for hackerone.com in 925 milliseconds 787 microseconds
```