### PR TITLE
Remove Lowercase Transformation for Case-Sensitive URLs

### DIFF
--- a/internal/runner/config.go
+++ b/internal/runner/config.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"os"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -22,7 +21,7 @@ func createProviderConfigYAML(configFilePath string) error {
 	sourcesRequiringApiKeysMap := make(map[string][]string)
 	for _, source := range agent.AllSources {
 		if source.NeedsKey() {
-			sourceName := strings.ToLower(source.Name())
+			sourceName := source.Name()
 			sourcesRequiringApiKeysMap[sourceName] = []string{}
 		}
 	}
@@ -40,7 +39,7 @@ func UnmarshalFrom(file string) error {
 	sourceApiKeysMap := map[string][]string{}
 	err = yaml.NewDecoder(reader).Decode(sourceApiKeysMap)
 	for _, source := range agent.AllSources {
-		sourceName := strings.ToLower(source.Name())
+		sourceName := (source.Name())
 		apiKeys := sourceApiKeysMap[sourceName]
 		if source.NeedsKey() && apiKeys != nil && len(apiKeys) > 0 {
 			gologger.Debug().Msgf("API key(s) found for %s.", sourceName)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -100,7 +100,7 @@ func (r *Runner) EnumerateMultipleUrls(reader io.Reader, writers []io.Writer) er
 func (r *Runner) EnumerateMultipleUrlsWithCtx(ctx context.Context, reader io.Reader, writers []io.Writer) error {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
-		url, err := normalizeLowercase(scanner.Text())
+		url, err := sanitize(scanner.Text())
 		if errors.Is(err, ErrEmptyInput) {
 			continue
 		}

--- a/internal/runner/util.go
+++ b/internal/runner/util.go
@@ -17,8 +17,3 @@ func sanitize(data string) (string, error) {
 	}
 	return data, nil
 }
-
-func normalizeLowercase(s string) (string, error) {
-	data, err := sanitize(s)
-	return strings.ToLower(data), err
-}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -63,7 +63,7 @@ func New(sourceNames, excludedSourceNames []string, useAllSources bool) *Agent {
 	gologger.Debug().Msg(fmt.Sprintf("Selected source(s) for this search: %s", strings.Join(maps.Keys(sources), ", ")))
 
 	for _, currentSource := range sources {
-		if warning, ok := sourceWarnings.Get(strings.ToLower(currentSource.Name())); ok {
+		if warning, ok := sourceWarnings.Get((currentSource.Name())); ok {
 			gologger.Warning().Msg(warning)
 		}
 	}
@@ -156,7 +156,7 @@ func (a *Agent) buildMultiRateLimiter(ctx context.Context, globalRateLimit int, 
 	var err error
 	for _, source := range a.sources {
 		var rl uint
-		if sourceRateLimit, ok := rateLimit.Custom.Get(strings.ToLower(source.Name())); ok {
+		if sourceRateLimit, ok := rateLimit.Custom.Get((source.Name())); ok {
 			rl = sourceRateLimitOrDefault(uint(globalRateLimit), sourceRateLimit)
 		}
 

--- a/pkg/extractor/regex_extractor.go
+++ b/pkg/extractor/regex_extractor.go
@@ -21,6 +21,5 @@ func NewRegexUrlExtractor() (*RegexUrlExtractor, error) {
 // Extract implements the UrlExtractor interface, using the regex to find urls in the given text.
 func (re *RegexUrlExtractor) Extract(text string) []string {
 	matches := re.extractor.FindAllString(text, -1)
-	// The copy step is unnecessary here; you can directly return matches
 	return matches
 }

--- a/pkg/extractor/regex_extractor.go
+++ b/pkg/extractor/regex_extractor.go
@@ -21,8 +21,6 @@ func NewRegexUrlExtractor() (*RegexUrlExtractor, error) {
 // Extract implements the UrlExtractor interface, using the regex to find urls in the given text.
 func (re *RegexUrlExtractor) Extract(text string) []string {
 	matches := re.extractor.FindAllString(text, -1)
-	for i, match := range matches {
-		matches[i] = (match)
-	}
+	// The copy step is unnecessary here; you can directly return matches
 	return matches
 }

--- a/pkg/extractor/regex_extractor.go
+++ b/pkg/extractor/regex_extractor.go
@@ -2,7 +2,6 @@ package extractor
 
 import (
 	"regexp"
-	"strings"
 )
 
 // RegexUrlExtractor is a concrete implementation of the RegexUrlExtractor interface, using regex for extraction.
@@ -23,7 +22,7 @@ func NewRegexUrlExtractor() (*RegexUrlExtractor, error) {
 func (re *RegexUrlExtractor) Extract(text string) []string {
 	matches := re.extractor.FindAllString(text, -1)
 	for i, match := range matches {
-		matches[i] = strings.ToLower(match)
+		matches[i] = (match)
 	}
 	return matches
 }

--- a/pkg/source/commoncrawl/commoncrawl.go
+++ b/pkg/source/commoncrawl/commoncrawl.go
@@ -140,7 +140,7 @@ func (s *Source) getURLs(ctx context.Context, searchURL, rootURL string, sess *s
 				line, _ = url.QueryUnescape(line)
 				for _, extractedURL := range sess.Extractor.Extract(line) {
 					// fix for triple encoded URL
-					extractedURL = strings.ToLower(extractedURL)
+					extractedURL = (extractedURL)
 					extractedURL = strings.TrimPrefix(extractedURL, "25")
 					extractedURL = strings.TrimPrefix(extractedURL, "2f")
 					if extractedURL != "" {

--- a/pkg/source/waybackarchive/waybackarchive.go
+++ b/pkg/source/waybackarchive/waybackarchive.go
@@ -49,7 +49,7 @@ func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session)
 			line, _ = url.QueryUnescape(line)
 			for _, extractedURL := range sess.Extractor.Extract(line) {
 				// fix for triple encoded URL
-				extractedURL = strings.ToLower(extractedURL)
+				extractedURL = (extractedURL)
 				extractedURL = strings.TrimPrefix(extractedURL, "25")
 				extractedURL = strings.TrimPrefix(extractedURL, "2f")
 


### PR DESCRIPTION
This PR removes the automatic transformation of URLs to lowercase across various modules. Many URLs are case-sensitive, and forcing them to lowercase may result in broken links or incorrect processing

Closes https://github.com/projectdiscovery/urlfinder/issues/35