### PR TITLE
add ext filter

### DIFF
--- a/internal/runner/config.go
+++ b/internal/runner/config.go
@@ -16,7 +16,9 @@ func createProviderConfigYAML(configFilePath string) error {
 	if err != nil {
 		return err
 	}
-	defer configFile.Close()
+	defer func() {
+		_ = configFile.Close()
+	}()
 
 	sourcesRequiringApiKeysMap := make(map[string][]string)
 	for _, source := range agent.AllSources {

--- a/internal/runner/enumerate.go
+++ b/internal/runner/enumerate.go
@@ -65,6 +65,10 @@ func (r *Runner) EnumerateSingleQueryWithCtx(ctx context.Context, query string, 
 				}
 
 				if matchUrl := r.filterAndMatchUrl(url); matchUrl {
+					if r.options.extensionValidator != nil && !r.options.extensionValidator.ValidatePath(url) {
+						gologger.Debug().Msgf("`%v` filtered by extension. skipping", url)
+						continue
+					}
 					if _, ok := uniqueMap[url]; !ok {
 						sourceMap[url] = make(map[string]struct{})
 					}

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -63,7 +63,7 @@ type Options struct {
 	filterRegexes      []*regexp.Regexp
 	ExtensionsMatch    goflags.StringSlice
 	ExtensionFilter    goflags.StringSlice
-	NoDefaultExtFilter bool // NoDefaultExtFilter disables default extension filtering
+	NoDefaultExtFilter bool
 	extensionValidator *extensions.Validator
 	ResultCallback     OnResultCallback // OnResult callback
 	DisableUpdateCheck bool             // DisableUpdateCheck disable update checking

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -62,7 +62,7 @@ type Options struct {
 	matchRegexes       []*regexp.Regexp
 	filterRegexes      []*regexp.Regexp
 	ExtensionsMatch    goflags.StringSlice
-	ExtensionFilter    goflags.StringSlice
+	ExtensionsFilter   goflags.StringSlice
 	NoDefaultExtFilter bool
 	extensionValidator *extensions.Validator
 	ResultCallback     OnResultCallback // OnResult callback
@@ -104,7 +104,7 @@ func ParseOptions() *Options {
 		flagSet.StringSliceVarP(&options.Match, "match", "m", nil, "url or list of url to match (file or comma separated)", goflags.FileNormalizedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.Filter, "filter", "f", nil, " url or list of url to filter (file or comma separated)", goflags.FileNormalizedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.ExtensionsMatch, "extension-match", "em", nil, "match output for given extension (eg, -em php,html,js)", goflags.CommaSeparatedStringSliceOptions),
-		flagSet.StringSliceVarP(&options.ExtensionFilter, "extension-filter", "ef", nil, "filter output for given extension (eg, -ef png,css)", goflags.CommaSeparatedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.ExtensionsFilter, "extension-filter", "ef", nil, "filter output for given extension (eg, -ef png,css)", goflags.CommaSeparatedStringSliceOptions),
 		flagSet.BoolVarP(&options.NoDefaultExtFilter, "no-default-ext-filter", "ndef", false, "remove default extensions from the filter list"),
 	)
 
@@ -244,7 +244,7 @@ func (options *Options) preProcessOptions() {
 
 	options.extensionValidator = extensions.NewValidator(
 		options.ExtensionsMatch,
-		options.ExtensionFilter,
+		options.ExtensionsFilter,
 		options.NoDefaultExtFilter,
 	)
 }

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -13,6 +13,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/urlfinder/pkg/agent"
 	"github.com/projectdiscovery/urlfinder/pkg/resolve"
+	"github.com/projectdiscovery/urlfinder/pkg/utils/extensions"
 	fileutil "github.com/projectdiscovery/utils/file"
 	folderutil "github.com/projectdiscovery/utils/folder"
 	logutil "github.com/projectdiscovery/utils/log"
@@ -60,6 +61,10 @@ type Options struct {
 	Filter             goflags.StringSlice
 	matchRegexes       []*regexp.Regexp
 	filterRegexes      []*regexp.Regexp
+	ExtensionsMatch    goflags.StringSlice
+	ExtensionFilter    goflags.StringSlice
+	NoDefaultExtFilter bool // NoDefaultExtFilter disables default extension filtering
+	extensionValidator *extensions.Validator
 	ResultCallback     OnResultCallback // OnResult callback
 	DisableUpdateCheck bool             // DisableUpdateCheck disable update checking
 }
@@ -98,6 +103,9 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("filter", "Filter",
 		flagSet.StringSliceVarP(&options.Match, "match", "m", nil, "url or list of url to match (file or comma separated)", goflags.FileNormalizedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.Filter, "filter", "f", nil, " url or list of url to filter (file or comma separated)", goflags.FileNormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.ExtensionsMatch, "extension-match", "em", nil, "match output for given extension (eg, -em php,html,js)", goflags.CommaSeparatedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.ExtensionFilter, "extension-filter", "ef", nil, "filter output for given extension (eg, -ef png,css)", goflags.CommaSeparatedStringSliceOptions),
+		flagSet.BoolVarP(&options.NoDefaultExtFilter, "no-default-ext-filter", "ndef", false, "remove default extensions from the filter list"),
 	)
 
 	flagSet.CreateGroup("rate-limit", "Rate-limit",
@@ -233,6 +241,12 @@ func (options *Options) preProcessOptions() {
 		options.URLs[i], _ = sanitize(url)
 
 	}
+
+	options.extensionValidator = extensions.NewValidator(
+		options.ExtensionsMatch,
+		options.ExtensionFilter,
+		options.NoDefaultExtFilter,
+	)
 }
 
 var defaultRateLimits = []string{

--- a/internal/runner/outputter.go
+++ b/internal/runner/outputter.go
@@ -96,7 +96,7 @@ func writePlainHostIP(_ string, results map[string]resolve.Result, writer io.Wri
 
 		_, err := bufwriter.WriteString(sb.String())
 		if err != nil {
-			bufwriter.Flush()
+			_ = bufwriter.Flush()
 			return err
 		}
 		sb.Reset()
@@ -153,7 +153,7 @@ func writePlainHost(_ string, results map[string]resolve.HostEntry, writer io.Wr
 
 		_, err := bufwriter.WriteString(sb.String())
 		if err != nil {
-			bufwriter.Flush()
+			_ = bufwriter.Flush()
 			return err
 		}
 		sb.Reset()
@@ -226,7 +226,7 @@ func writeSourcePlainHost(_ string, sourceMap map[string]map[string]struct{}, wr
 
 		_, err := bufwriter.WriteString(sb.String())
 		if err != nil {
-			bufwriter.Flush()
+			_ = bufwriter.Flush()
 			return err
 		}
 		sb.Reset()

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -129,7 +129,7 @@ func (r *Runner) EnumerateMultipleUrlsWithCtx(ctx context.Context, reader io.Rea
 
 			err = r.EnumerateSingleQueryWithCtx(ctx, url, append(writers, file))
 
-			file.Close()
+			_ = file.Close()
 		} else if r.options.OutputDirectory != "" {
 			outputFile := path.Join(r.options.OutputDirectory, url)
 			if r.options.JSON {
@@ -147,7 +147,7 @@ func (r *Runner) EnumerateMultipleUrlsWithCtx(ctx context.Context, reader io.Rea
 
 			err = r.EnumerateSingleQueryWithCtx(ctx, url, append(writers, file))
 
-			file.Close()
+			_ = file.Close()
 		} else {
 			err = r.EnumerateSingleQueryWithCtx(ctx, url, writers)
 		}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -142,7 +142,7 @@ func (s *Session) DiscardHTTPResponse(response *http.Response) {
 			gologger.Warning().Msgf("Could not discard response body: %s\n", err)
 			return
 		}
-		response.Body.Close()
+		_ = response.Body.Close()
 	}
 }
 

--- a/pkg/source/alienvault/alienvault.go
+++ b/pkg/source/alienvault/alienvault.go
@@ -57,10 +57,10 @@ func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session)
 			if err != nil {
 				results <- source.Result{Source: s.Name(), Error: err}
 				s.errors++
-				resp.Body.Close()
+				_ = resp.Body.Close()
 				return
 			}
-			resp.Body.Close()
+			_ = resp.Body.Close()
 
 			for _, record := range response.URLList {
 				for _, extractedURL := range sess.Extractor.Extract(record.URL) {

--- a/pkg/source/commoncrawl/commoncrawl.go
+++ b/pkg/source/commoncrawl/commoncrawl.go
@@ -57,10 +57,10 @@ func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session)
 		if err != nil {
 			results <- source.Result{Source: s.Name(), Error: err}
 			s.errors++
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		years := make([]string, 0)
 		for i := 0; i < maxYearsBack; i++ {
@@ -149,7 +149,7 @@ func (s *Source) getURLs(ctx context.Context, searchURL, rootURL string, sess *s
 					}
 				}
 			}
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return true
 		}
 	}

--- a/pkg/source/urlscan/urlscan.go
+++ b/pkg/source/urlscan/urlscan.go
@@ -77,10 +77,10 @@ func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session)
 			if err != nil {
 				results <- source.Result{Source: s.Name(), Error: err}
 				s.errors++
-				resp.Body.Close()
+				_ = resp.Body.Close()
 				return
 			}
-			resp.Body.Close()
+			_ = resp.Body.Close()
 
 			if resp.StatusCode == http.StatusTooManyRequests {
 				results <- source.Result{Source: s.Name(), Error: fmt.Errorf("urlscan rate limited")}

--- a/pkg/source/virustotal/virustotal.go
+++ b/pkg/source/virustotal/virustotal.go
@@ -50,7 +50,9 @@ func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session)
 			sess.DiscardHTTPResponse(resp)
 			return
 		}
-		defer resp.Body.Close()
+		defer func() {
+			_ = resp.Body.Close()
+		}()
 
 		var data response
 		err = json.NewDecoder(resp.Body).Decode(&data)

--- a/pkg/source/waybackarchive/waybackarchive.go
+++ b/pkg/source/waybackarchive/waybackarchive.go
@@ -38,7 +38,9 @@ func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session)
 			return
 		}
 
-		defer resp.Body.Close()
+		defer func() {
+			_ = resp.Body.Close()
+		}()
 
 		scanner := bufio.NewScanner(resp.Body)
 		for scanner.Scan() {

--- a/pkg/utils/extensions/extensions.go
+++ b/pkg/utils/extensions/extensions.go
@@ -1,0 +1,76 @@
+package extensions
+
+import (
+	"path"
+	"strings"
+
+	"github.com/projectdiscovery/gologger"
+	urlutil "github.com/projectdiscovery/utils/url"
+)
+
+// defaultExtFilter is the default list of extensions to be denied
+var defaultExtFilter = []string{".3g2", ".3gp", ".7z", ".apk", ".arj", ".avi", ".axd", ".bmp", ".csv", ".deb", ".dll", ".doc", ".drv", ".eot", ".exe", ".flv", ".gif", ".gifv", ".gz", ".h264", ".ico", ".iso", ".jar", ".jpeg", ".jpg", ".lock", ".m4a", ".m4v", ".map", ".mkv", ".mov", ".mp3", ".mp4", ".mpeg", ".mpg", ".msi", ".ogg", ".ogm", ".ogv", ".otf", ".pdf", ".pkg", ".png", ".ppt", ".psd", ".rar", ".rm", ".rpm", ".svg", ".swf", ".sys", ".tar.gz", ".tar", ".tif", ".tiff", ".ttf", ".txt", ".vob", ".wav", ".webm", ".webp", ".wmv", ".woff", ".woff2", ".xcf", ".xls", ".xlsx", ".zip"}
+
+// Validator is a validator for file extension
+type Validator struct {
+	extensionsMatch  map[string]struct{}
+	extensionsFilter map[string]struct{}
+}
+
+// NewValidator creates a new extension validator instance
+func NewValidator(extensionsMatch, extensionsFilter []string, noDefaultExtFilter bool) *Validator {
+	validator := &Validator{
+		extensionsMatch:  make(map[string]struct{}),
+		extensionsFilter: make(map[string]struct{}),
+	}
+
+	for _, extension := range extensionsMatch {
+		validator.extensionsMatch[normalizeExtension(extension)] = struct{}{}
+	}
+	if !noDefaultExtFilter {
+		for _, item := range defaultExtFilter {
+			validator.extensionsFilter[normalizeExtension(item)] = struct{}{}
+		}
+	}
+	for _, extension := range extensionsFilter {
+		validator.extensionsFilter[normalizeExtension(extension)] = struct{}{}
+	}
+	return validator
+}
+
+// ValidatePath returns true if an extension is allowed by the validator
+func (e *Validator) ValidatePath(item string) bool {
+	var extension string
+	u, err := urlutil.Parse(item)
+	if err != nil {
+		gologger.Warning().Msgf("validatepath: failed to parse url %v got %v", item, err)
+		return false
+	}
+	if u.Path != "" {
+		extension = strings.ToLower(path.Ext(u.Path))
+	} else {
+		extension = strings.ToLower(path.Ext(item))
+	}
+	if extension == "" && len(e.extensionsMatch) > 0 {
+		return false
+	}
+	if len(e.extensionsMatch) > 0 {
+		if _, ok := e.extensionsMatch[extension]; ok {
+			return true
+		}
+		return false
+	}
+
+	if _, ok := e.extensionsFilter[extension]; ok {
+		return false
+	}
+	return true
+}
+
+func normalizeExtension(extension string) string {
+	extension = strings.ToLower(extension)
+	if strings.HasPrefix(extension, ".") {
+		return extension
+	}
+	return "." + extension
+}

--- a/pkg/utils/extensions/extensions_test.go
+++ b/pkg/utils/extensions/extensions_test.go
@@ -1,0 +1,205 @@
+package extensions
+
+import (
+	"testing"
+)
+
+func TestNewValidator(t *testing.T) {
+	// Test basic constructor functionality
+	validator := NewValidator([]string{".html", ".php"}, []string{".exe", ".dll"}, true)
+
+	if validator == nil {
+		t.Error("Expected validator to be created, got nil")
+	}
+
+	// Test with default filter
+	validatorWithDefault := NewValidator([]string{}, []string{}, false)
+	if validatorWithDefault == nil {
+		t.Error("Expected validator with default filter to be created, got nil")
+	}
+
+	// Test without default filter
+	validatorNoDefault := NewValidator([]string{}, []string{}, true)
+	if validatorNoDefault == nil {
+		t.Error("Expected validator without default filter to be created, got nil")
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	// Test matching behavior
+	t.Run("Match extensions", func(t *testing.T) {
+		validator := NewValidator([]string{".html", ".php"}, []string{}, true)
+
+		// Should match .html
+		if !validator.ValidatePath("https://example.com/page.html") {
+			t.Error("Expected .html to match")
+		}
+
+		// Should match .php
+		if !validator.ValidatePath("https://example.com/page.php") {
+			t.Error("Expected .php to match")
+		}
+
+		// Should not match .asp
+		if validator.ValidatePath("https://example.com/page.asp") {
+			t.Error("Expected .asp to not match")
+		}
+
+		// Should not match no extension
+		if validator.ValidatePath("https://example.com/page") {
+			t.Error("Expected no extension to not match when match list is specified")
+		}
+	})
+
+	// Test filtering behavior
+	t.Run("Filter extensions", func(t *testing.T) {
+		validator := NewValidator([]string{}, []string{".exe", ".dll"}, true)
+
+		// Should allow .html
+		if !validator.ValidatePath("https://example.com/page.html") {
+			t.Error("Expected .html to be allowed")
+		}
+
+		// Should block .exe
+		if validator.ValidatePath("https://example.com/file.exe") {
+			t.Error("Expected .exe to be blocked")
+		}
+
+		// Should block .dll
+		if validator.ValidatePath("https://example.com/file.dll") {
+			t.Error("Expected .dll to be blocked")
+		}
+
+		// Should allow no extension
+		if !validator.ValidatePath("https://example.com/page") {
+			t.Error("Expected no extension to be allowed")
+		}
+	})
+
+	// Test case insensitive
+	t.Run("Case insensitive", func(t *testing.T) {
+		validator := NewValidator([]string{".html"}, []string{".exe"}, true)
+
+		// Should match .HTML (uppercase)
+		if !validator.ValidatePath("https://example.com/page.HTML") {
+			t.Error("Expected .HTML to match")
+		}
+
+		// Should block .EXE (uppercase)
+		if validator.ValidatePath("https://example.com/file.EXE") {
+			t.Error("Expected .EXE to be blocked")
+		}
+	})
+
+	// Test default filter
+	t.Run("Default filter", func(t *testing.T) {
+		validator := NewValidator([]string{}, []string{}, false)
+
+		// Should allow .html (not in default filter)
+		if !validator.ValidatePath("https://example.com/page.html") {
+			t.Error("Expected .html to be allowed with default filter")
+		}
+
+		// Should block .pdf (in default filter)
+		if validator.ValidatePath("https://example.com/document.pdf") {
+			t.Error("Expected .pdf to be blocked by default filter")
+		}
+	})
+
+	// Test edge cases
+	t.Run("Edge cases", func(t *testing.T) {
+		validator := NewValidator([]string{}, []string{}, true)
+
+		// Empty URL should fail
+		if validator.ValidatePath("") {
+			t.Error("Expected empty URL to fail")
+		}
+
+		// Invalid URL should fail
+		if validator.ValidatePath("://invalid") {
+			t.Error("Expected invalid URL to fail")
+		}
+
+		// URL without path should pass
+		if !validator.ValidatePath("https://example.com") {
+			t.Error("Expected URL without path to pass")
+		}
+	})
+}
+
+func TestNormalizeExtension(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{".html", ".html"},
+		{"html", ".html"},
+		{".HTML", ".html"},
+		{"HTML", ".html"},
+		{".php", ".php"},
+		{"php", ".php"},
+		{".PHP", ".php"},
+		{"PHP", ".php"},
+		{".exe", ".exe"},
+		{"exe", ".exe"},
+		{".EXE", ".exe"},
+		{"EXE", ".exe"},
+		{"", "."},
+		{".", "."},
+		{"..", ".."},
+		{".tar.gz", ".tar.gz"},
+		{"tar.gz", ".tar.gz"},
+		{".TAR.GZ", ".tar.gz"},
+		{"TAR.GZ", ".tar.gz"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := normalizeExtension(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeExtension(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultExtFilter(t *testing.T) {
+	// Test that default filter contains expected extensions
+	expectedExtensions := []string{".pdf", ".jpg", ".zip", ".exe", ".dll"}
+
+	for _, ext := range expectedExtensions {
+		found := false
+		for _, defaultExt := range defaultExtFilter {
+			if defaultExt == ext {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected extension %q not found in default filter", ext)
+		}
+	}
+}
+
+func TestValidatorEdgeCases(t *testing.T) {
+	// Test with nil slices
+	validator := NewValidator(nil, nil, true)
+	if validator == nil {
+		t.Error("Expected validator to be created with nil slices")
+	}
+
+	// Test with duplicate extensions
+	validator = NewValidator([]string{".html", ".html", ".php"}, []string{".exe", ".exe", ".dll"}, true)
+	if validator == nil {
+		t.Error("Expected validator to be created with duplicate extensions")
+	}
+
+	// Test ValidatePath with empty validator
+	validator = NewValidator([]string{}, []string{}, true)
+	if !validator.ValidatePath("https://example.com/page.html") {
+		t.Error("Expected empty validator to allow all extensions")
+	}
+	if !validator.ValidatePath("https://example.com/page") {
+		t.Error("Expected empty validator to allow URLs without extensions")
+	}
+}


### PR DESCRIPTION
closes https://github.com/projectdiscovery/urlfinder/issues/47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extension-based filtering for URL enumeration with CLI flags to include or exclude file extensions; option to disable the default deny-list.

* **Chores**
  * Quieted spurious error reporting from resource/network cleanup by ignoring close/flush errors to reduce noisy runtime logs.

* **Tests**
  * Added unit tests covering the extension validator behavior, normalization, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->