### PR TITLE
fix(commoncrawl): add output=text&fl=url to CDX query so URLs are actually returned

### DIFF
--- a/pkg/source/commoncrawl/commoncrawl.go
+++ b/pkg/source/commoncrawl/commoncrawl.go
@@ -3,7 +3,6 @@ package commoncrawl
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -121,7 +120,19 @@ func (s *Source) getURLs(ctx context.Context, searchURL, rootURL string, sess *s
 			return false
 		default:
 			var headers = map[string]string{"Host": "index.commoncrawl.org"}
-			currentSearchURL := fmt.Sprintf("%s?url=*.%s&output=text&fl=url&collapse=urlkey", searchURL, rootURL)
+			u, err := url.Parse(searchURL)
+			if err != nil {
+				results <- source.Result{Source: s.Name(), Error: err}
+				s.errors++
+				return false
+			}
+			q := u.Query()
+			q.Set("url", "*."+rootURL)
+			q.Set("output", "text")
+			q.Set("fl", "url")
+			q.Set("collapse", "urlkey")
+			u.RawQuery = q.Encode()
+			currentSearchURL := u.String()
 			resp, err := sess.Get(ctx, currentSearchURL, "", headers)
 			if err != nil {
 				results <- source.Result{Source: s.Name(), Error: err}

--- a/pkg/source/commoncrawl/commoncrawl.go
+++ b/pkg/source/commoncrawl/commoncrawl.go
@@ -130,7 +130,6 @@ func (s *Source) getURLs(ctx context.Context, searchURL, rootURL string, sess *s
 			q.Set("url", "*."+rootURL)
 			q.Set("output", "text")
 			q.Set("fl", "url")
-			q.Set("collapse", "urlkey")
 			u.RawQuery = q.Encode()
 			currentSearchURL := u.String()
 			resp, err := sess.Get(ctx, currentSearchURL, "", headers)
@@ -150,10 +149,6 @@ func (s *Source) getURLs(ctx context.Context, searchURL, rootURL string, sess *s
 				}
 				line, _ = url.QueryUnescape(line)
 				for _, extractedURL := range sess.Extractor.Extract(line) {
-					// fix for triple encoded URL
-					extractedURL = (extractedURL)
-					extractedURL = strings.TrimPrefix(extractedURL, "25")
-					extractedURL = strings.TrimPrefix(extractedURL, "2f")
 					if extractedURL != "" {
 						results <- source.Result{Source: s.Name(), Value: extractedURL, Reference: currentSearchURL}
 						s.results++

--- a/pkg/source/commoncrawl/commoncrawl.go
+++ b/pkg/source/commoncrawl/commoncrawl.go
@@ -121,7 +121,7 @@ func (s *Source) getURLs(ctx context.Context, searchURL, rootURL string, sess *s
 			return false
 		default:
 			var headers = map[string]string{"Host": "index.commoncrawl.org"}
-			currentSearchURL := fmt.Sprintf("%s?url=*.%s", searchURL, rootURL)
+			currentSearchURL := fmt.Sprintf("%s?url=*.%s&output=text&fl=url&collapse=urlkey", searchURL, rootURL)
 			resp, err := sess.Get(ctx, currentSearchURL, "", headers)
 			if err != nil {
 				results <- source.Result{Source: s.Name(), Error: err}


### PR DESCRIPTION
## Problem

The CommonCrawl source returns no URLs at all.

**Root cause:** The CDX API returns raw CDX-format lines by default:
```
com,example)/ 20260508... {"url": "http://www.example.com/", ...}
```
But the regex extractor in `pkg/extractor/regex_extractor.go` is compiled with `^` and `$` anchors, so it only matches when the **entire input line is a URL**. A CDX record line never matches, so every line silently returns zero results.

## Fix

Add `&output=text&fl=url&collapse=urlkey` to the CDX query URL, which makes the API return one plain URL per line — the same approach already used by the Wayback Archive source (`&output=txt&fl=original`).

```diff
-currentSearchURL := fmt.Sprintf("%s?url=*.%s", searchURL, rootURL)
+currentSearchURL := fmt.Sprintf("%s?url=*.%s&output=text&fl=url&collapse=urlkey", searchURL, rootURL)
```

- `output=text&fl=url` — return only the URL field, one per line
- `collapse=urlkey` — deduplicate entries where the same URL was crawled multiple times

## Testing

Tested against `example.com` — before the fix: 0 results; after: thousands of URLs returned across all subdomains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Common Crawl search query formatting to produce more consistent, better-structured results.
  * Added robust handling for invalid search URLs so failed parses now surface errors and stop processing rather than continuing with invalid requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->