### PR TITLE
fix commoncrawl and waybackarchive source errors

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -19,4 +19,4 @@ jobs:
         uses: projectdiscovery/actions/setup/go@v1
 
       - name: Run golangci-lint
-        uses: projectdiscovery/actions/golangci-lint@v1
+        uses: projectdiscovery/actions/golangci-lint/v2@v1

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/projectdiscovery/utils v0.11.1
 	github.com/rs/xid v1.6.0
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/exp v0.0.0-20260112195511-716be5621a96
 	golang.org/x/net v0.55.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -86,6 +85,7 @@ require (
 	github.com/zcalusic/sysinfo v1.1.3 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -44,7 +44,7 @@ type Options struct {
 	NoScope            bool                // NoScope disables host based default scope
 	DisplayOutScope    bool                // DisplayOutScope displays external endpoint from scoped crawling
 	Statistics         bool                // Statistics specifies whether to report source statistics
-	Timeout            int                 // Timeout is the seconds to wait for sources to respond
+	Timeout            int                 // Timeout is the seconds to wait when connecting to a source
 	MaxEnumerationTime int                 // MaxEnumerationTime is the maximum amount of time in minutes to wait for enumeration
 	URLs               goflags.StringSlice // URLs is the url to find urls for
 	Output             io.Writer
@@ -141,7 +141,7 @@ func ParseOptions() *Options {
 	)
 
 	flagSet.CreateGroup("optimization", "Optimization",
-		flagSet.IntVar(&options.Timeout, "timeout", 30, "seconds to wait before timing out"),
+		flagSet.IntVar(&options.Timeout, "timeout", 30, "seconds to wait before timing out when connecting to a source"),
 		flagSet.IntVar(&options.MaxEnumerationTime, "max-time", 10, "minutes to wait for enumeration results"),
 	)
 

--- a/internal/runner/stats.go
+++ b/internal/runner/stats.go
@@ -2,19 +2,18 @@ package runner
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/urlfinder/pkg/source"
-	"golang.org/x/exp/maps"
 )
 
 func printStatistics(stats map[string]source.Statistics) {
 
-	sources := maps.Keys(stats)
-	sort.Strings(sources)
+	sources := slices.Sorted(maps.Keys(stats))
 
 	var lines []string
 	var skipped []string

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -3,14 +3,13 @@ package agent
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math"
 	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/ratelimit"
@@ -60,7 +59,7 @@ func New(sourceNames, excludedSourceNames []string, useAllSources bool) *Agent {
 		gologger.Fatal().Msg("No sources selected for this search")
 	}
 
-	gologger.Debug().Msg(fmt.Sprintf("Selected source(s) for this search: %s", strings.Join(maps.Keys(sources), ", ")))
+	gologger.Debug().Msg(fmt.Sprintf("Selected source(s) for this search: %s", strings.Join(slices.Sorted(maps.Keys(sources)), ", ")))
 
 	for _, currentSource := range sources {
 		if warning, ok := sourceWarnings.Get((currentSource.Name())); ok {
@@ -69,7 +68,7 @@ func New(sourceNames, excludedSourceNames []string, useAllSources bool) *Agent {
 	}
 
 	// Create the agent, insert the sources and remove the excluded sources
-	agent := &Agent{sources: maps.Values(sources)}
+	agent := &Agent{sources: slices.Collect(maps.Values(sources))}
 
 	return agent
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -48,9 +48,10 @@ func NewSession(query string, proxy string, multiRateLimiter *ratelimit.MultiLim
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout: time.Duration(timeout) * time.Second,
-		}).Dial,
+		}).DialContext,
+		TLSHandshakeTimeout: time.Duration(timeout) * time.Second,
 	}
 
 	// Add proxy
@@ -64,9 +65,11 @@ func NewSession(query string, proxy string, multiRateLimiter *ratelimit.MultiLim
 		}
 	}
 
+	// timeout bounds connection setup only, not the whole exchange: sources like
+	// waybackarchive stream large responses for minutes, and a client-wide timeout
+	// aborts them mid-body. The request context (-max-time) bounds the request overall.
 	client := &http.Client{
 		Transport: Transport,
-		Timeout:   time.Duration(timeout) * time.Second,
 	}
 
 	session := &Session{Client: client}

--- a/pkg/source/commoncrawl/commoncrawl.go
+++ b/pkg/source/commoncrawl/commoncrawl.go
@@ -17,6 +17,10 @@ import (
 const (
 	indexURL     = "https://index.commoncrawl.org/collinfo.json"
 	maxYearsBack = 5
+
+	// cdx lines can exceed bufio.Scanner's 64KB default, which silently truncates results
+	initialScanBuffer = 64 * 1024
+	maxScanBuffer     = 4 * 1024 * 1024
 )
 
 var year = time.Now().Year()
@@ -45,7 +49,7 @@ func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session)
 
 		resp, err := sess.SimpleGet(ctx, indexURL)
 		if err != nil {
-			results <- source.Result{Source: s.Name(), Error: err}
+			results <- source.Result{Source: s.Name(), Type: source.Error, Error: err}
 			s.errors++
 			sess.DiscardHTTPResponse(resp)
 			return
@@ -54,7 +58,7 @@ func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session)
 		var indexes []indexResponse
 		err = jsoniter.NewDecoder(resp.Body).Decode(&indexes)
 		if err != nil {
-			results <- source.Result{Source: s.Name(), Error: err}
+			results <- source.Result{Source: s.Name(), Type: source.Error, Error: err}
 			s.errors++
 			_ = resp.Body.Close()
 			return
@@ -78,10 +82,15 @@ func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session)
 			}
 		}
 
-		for _, apiURL := range searchIndexes {
-			further := s.getURLs(ctx, apiURL, rootUrl, sess, results)
-			if !further {
+		// iterate over years rather than the map so the order is deterministic, and
+		// keep going when an index errors out: the commoncrawl index frontend returns
+		// intermittent 502/504s, and one bad index shouldn't discard the others.
+		for _, year := range years {
+			if ctx.Err() != nil {
 				break
+			}
+			if apiURL, ok := searchIndexes[year]; ok {
+				s.getURLs(ctx, apiURL, rootUrl, sess, results)
 			}
 		}
 	}()
@@ -113,50 +122,50 @@ func (s *Source) Statistics() source.Statistics {
 	}
 }
 
-func (s *Source) getURLs(ctx context.Context, searchURL, rootURL string, sess *session.Session, results chan source.Result) bool {
-	for {
-		select {
-		case <-ctx.Done():
-			return false
-		default:
-			var headers = map[string]string{"Host": "index.commoncrawl.org"}
-			u, err := url.Parse(searchURL)
-			if err != nil {
-				results <- source.Result{Source: s.Name(), Error: err}
-				s.errors++
-				return false
-			}
-			q := u.Query()
-			q.Set("url", "*."+rootURL)
-			q.Set("output", "text")
-			q.Set("fl", "url")
-			u.RawQuery = q.Encode()
-			currentSearchURL := u.String()
-			resp, err := sess.Get(ctx, currentSearchURL, "", headers)
-			if err != nil {
-				results <- source.Result{Source: s.Name(), Error: err}
-				s.errors++
-				sess.DiscardHTTPResponse(resp)
-				return false
-			}
+func (s *Source) getURLs(ctx context.Context, searchURL, rootURL string, sess *session.Session, results chan source.Result) {
+	var headers = map[string]string{"Host": "index.commoncrawl.org"}
+	u, err := url.Parse(searchURL)
+	if err != nil {
+		results <- source.Result{Source: s.Name(), Type: source.Error, Error: err}
+		s.errors++
+		return
+	}
+	q := u.Query()
+	q.Set("url", "*."+rootURL)
+	q.Set("output", "text")
+	q.Set("fl", "url")
+	u.RawQuery = q.Encode()
+	currentSearchURL := u.String()
+	resp, err := sess.Get(ctx, currentSearchURL, "", headers)
+	if err != nil {
+		results <- source.Result{Source: s.Name(), Type: source.Error, Error: err}
+		s.errors++
+		sess.DiscardHTTPResponse(resp)
+		return
+	}
 
-			scanner := bufio.NewScanner(resp.Body)
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
-			for scanner.Scan() {
-				line := scanner.Text()
-				if line == "" {
-					continue
-				}
-				line, _ = url.QueryUnescape(line)
-				for _, extractedURL := range sess.Extractor.Extract(line) {
-					if extractedURL != "" {
-						results <- source.Result{Source: s.Name(), Value: extractedURL, Reference: currentSearchURL}
-						s.results++
-					}
-				}
-			}
-			_ = resp.Body.Close()
-			return true
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, initialScanBuffer), maxScanBuffer)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
 		}
+		line, _ = url.QueryUnescape(line)
+		for _, extractedURL := range sess.Extractor.Extract(line) {
+			if extractedURL != "" {
+				results <- source.Result{Source: s.Name(), Value: extractedURL, Reference: currentSearchURL}
+				s.results++
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		results <- source.Result{Source: s.Name(), Type: source.Error, Error: err}
+		s.errors++
 	}
 }

--- a/pkg/source/waybackarchive/waybackarchive.go
+++ b/pkg/source/waybackarchive/waybackarchive.go
@@ -12,6 +12,12 @@ import (
 	"github.com/projectdiscovery/urlfinder/pkg/source"
 )
 
+const (
+	// cdx lines can exceed bufio.Scanner's 64KB default, which silently truncates results
+	initialScanBuffer = 64 * 1024
+	maxScanBuffer     = 4 * 1024 * 1024
+)
+
 type Source struct {
 	timeTaken time.Duration
 	errors    int
@@ -43,6 +49,7 @@ func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session)
 		}()
 
 		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, initialScanBuffer), maxScanBuffer)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if line == "" {
@@ -59,6 +66,10 @@ func (s *Source) Run(ctx context.Context, rootUrl string, sess *session.Session)
 				s.results++
 			}
 
+		}
+		if err := scanner.Err(); err != nil {
+			results <- source.Result{Source: s.Name(), Type: source.Error, Error: err}
+			s.errors++
 		}
 	}()
 


### PR DESCRIPTION
Closes #133

Two unrelated causes behind the reported errors:

- **commoncrawl**: `getURLs` returned `false` on any HTTP error, which `break`ed out of the loop over all 5 yearly indexes. Common Crawl's index frontend intermittently returns 502/504, and since the indexes were iterated from a map (random order), a single bad index would discard the remaining four at random. Now iterates years in order and keeps going past a failed index.
- **waybackarchive**: `http.Client.Timeout` was set from `-timeout` (default 30s), which bounds the *entire* exchange including the response body. Wayback's CDX API regularly needs longer than that just to send headers, and a full response streams for minutes, so it failed with `context deadline exceeded ... while awaiting headers` on essentially any real domain. `-timeout` now applies to connection setup (dial + TLS handshake). The request as a whole is still bounded by `-max-time`.

Also: both sources used `bufio.Scanner` at its default 64KB limit and never checked `scanner.Err()`, so an over-long CDX line silently truncated results. Added a larger buffer and error reporting. Tagged commoncrawl's error results with `Type: source.Error`. Without it `enumerate.go` treated them as URL results and never logged the warning.

Before / after on `-d projectdiscovery.io`, default flags:

```
# before                          # after
commoncrawl     0 results 1 err    commoncrawl     1414 results 0 err
commoncrawl     0 results 1 err    commoncrawl     1414 results 0 err
commoncrawl  ~1400 results 0 err   commoncrawl     1414 results 0 err
waybackarchive  0 results 1 err    waybackarchive 33360 results 0 err
```

Note wayback remains flaky upstream independent of this change. web.archive.org sometimes holds the connection ~4.5 min and then closes it without sending headers (`EOF`). That is server-side, so a retry could be a follow-up.

---

### CI fixes (unrelated to #133, needed to get this PR green)

`lint-test` was already broken on `dev`. golangci-lint `v1.64.8` is built with Go 1.24 and refuses a target above that, so it exited during config load:

```
can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
```

Dependabot raised `go.mod` to `go 1.25.0` in e91a803, but `lint-test.yml` skips bot actors, so every dependabot PR since reported `skipping` and nothing caught it. This is the first non-bot PR since that bump.

- Switched to `projectdiscovery/actions/golangci-lint/v2@v1` (golangci-lint v2, `golangci-lint-action@v9`). v1.64.8 is the final v1 release, so there was no newer v1 to pin.
- That surfaced one pre-existing finding, `govet` `inline` on `maps.Copy` in `pkg/agent/agent.go`, caused by the `//go:fix inline` directives in `golang.org/x/exp/maps`. Migrated `agent.go` and `stats.go` to the stdlib `maps` package, which drops the deprecated dependency (`go mod tidy` demotes `x/exp` to indirect). Side benefit: the "Selected source(s)" debug line and the stats table are now deterministically ordered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified that the timeout setting applies to establishing connections with sources.
  * Improved long-lived response streaming by preventing client-wide timeouts from interrupting active transfers.
  * Improved Common Crawl processing so one failed index does not stop other years from being searched.
  * Added clearer error reporting when archive responses cannot be scanned or processed.
  * Improved handling of large Common Crawl and Wayback Archive records.
  * Made archive index processing more consistent and reliable across searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->